### PR TITLE
Check if the window system is enabled

### DIFF
--- a/eon.el
+++ b/eon.el
@@ -569,10 +569,12 @@ Some themes may come as functions -- wrap these ones in lambdas."
 (menu-bar-mode 1)
 
 ;; Scroll bar: on/off by default?
-(scroll-bar-mode -1)
+(when (display-graphic-p)
+  (scroll-bar-mode -1))
 
 ;; Tool bar: on/off by default?
-(tool-bar-mode -1)
+(when (display-graphic-p)
+  (tool-bar-mode -1))
 
 ;; Tooltips: enable/disable?
 (tooltip-mode -1)


### PR DESCRIPTION
Load `eon.el` into Emacs in a terminal accessed via SSH, `scroll-bar-mode` and `tool-bar-mode` are undefined, so make sure the window system is enabled before calling these two functions.